### PR TITLE
user_reactionsテーブルに複合キーを設定

### DIFF
--- a/Docker/MySQL/init.sql
+++ b/Docker/MySQL/init.sql
@@ -51,7 +51,9 @@ CREATE TABLE user_reactions (
   user_id varchar(255) NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   deleted_at TIMESTAMP NULL,
+  UNIQUE INDEX user_message_reaction_unique (user_id, message_id, reaction_id),
   FOREIGN KEY (message_id) REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (reaction_id) REFERENCES reactions(id) ON DELETE CASCADE ON UPDATE CASCADE,
   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE ON UPDATE CASCADE
 );
 


### PR DESCRIPTION
user_reactionsテーブルに複合キーを設定しました。
これにより、1ユーザーが同じリアクションをしないように制限がかけられるかと思います。

現在、メンターの方にテーブルの添削をいただいているので変更があるかもしれません。
そのため、このプルリクは一時的なものになり、いつものフォーマットを無視しています。すみません。
メンターの方の返事が返ってきたら再度pushいたします。

リアクション機能のところになるため、mizunoさんにはご迷惑おかけしますが、
何卒よろしくお願いいたします。