### PR TITLE
feature/Frontend-111-2

### DIFF
--- a/ChatApp/static/CSS/detail.css
+++ b/ChatApp/static/CSS/detail.css
@@ -16,7 +16,6 @@
   top: 0;
   right: 0;
   left: 0;
-
   font-weight: 600;
   display: flex;
   align-items: center;
@@ -63,7 +62,7 @@ a.fa-home{
   text-decoration: none;
 }
 
-.pinned-message-area {
+#pinned-message-area {
   background-color: var(--yellow);
   height: 8vh;
   width: 100vw;
@@ -79,20 +78,16 @@ a.fa-home{
 
 #pinned-message{
   margin-left: 2rem;
-
 }
 
-/* <!--------- feature/141はここまでです ----------> */
-
 #message-area {
-  min-height: 100vh;
   width: 100%;
-  padding-top: 16vh;
-  overflow-y: scroll;
-  overflow-x: hidden;
+  margin-top: 14vh;
   display: flex;
   flex-direction: column;
   gap: 0.6rem;
+  padding-top: 2rem;
+  padding-bottom: 20vh;
 }
 
 ::-webkit-scrollbar {
@@ -261,6 +256,10 @@ a.fa-home{
 
 #add-message-button:hover {
   color: var(--orange);
+}
+
+#no-message{
+  text-align: center;
 }
 
 /* ========================================================== */

--- a/ChatApp/static/CSS/main.css
+++ b/ChatApp/static/CSS/main.css
@@ -50,6 +50,7 @@ a.fa-solid{
 }
 
 .pagination {
+  display: flex;
   padding-left: 0;
   max-width: 50vw;
 }
@@ -57,10 +58,16 @@ a.fa-solid{
 .pagination li {
   color: var(--black);
   width: 20px;
-  font-weight: bold;
   list-style: none;
   display: flex;
   justify-content: center;
+  margin: 0.5em;
+  line-height: 1;
+}
+
+.pagination li.colored{
+  font-weight: bold;
+  border-bottom:solid 2px var(--grey)
 }
 
 #prev,

--- a/ChatApp/static/CSS/registration.css
+++ b/ChatApp/static/CSS/registration.css
@@ -122,12 +122,12 @@
 }
 
 .flashes{
+  color: var(--red);
   padding: 0;
   margin-left: auto;
 }
 
 .flashes li,#visibility-flash{
-  color: var(--red);
   list-style: none;
 }
 
@@ -193,5 +193,4 @@
     margin: 0;
     padding-left: 0.5rem;
   }
-
 }

--- a/ChatApp/static/JS/chatbox-size.js
+++ b/ChatApp/static/JS/chatbox-size.js
@@ -1,0 +1,9 @@
+const pinnedArea = document.getElementById('pinned-message-area');
+const messageArea = document.getElementById('message-area');
+console.log(pinnedArea != null)
+if (pinnedArea != null){
+    ;
+}else{
+    messageArea.style.marginTop = '8vh'
+}
+

--- a/ChatApp/static/JS/pagination.js
+++ b/ChatApp/static/JS/pagination.js
@@ -1,24 +1,12 @@
-// チャンネル一覧ページでレスポンスが返ってきた後、
-// 送られてきたチャンネル一覧の配列をもとにページネーションの追加/チャンネルリストの表示を行う処理。
-
 const deleteChannelModal = document.getElementById("delete-channel-modal");
-
-// paginationでチャンネル一覧を追加した後、「チャンネル登録ボタン」を追加
-// ボタンを追加した後に「loadAddChannelButton関数（add-channel.js内）」を呼び出したい。
-// なのでここのpagination関数はasyncにしている。
 const pagination = async () => {
-  let page = 1; // 今何ページ目にいるか
-  const STEP = 6; // ステップ数（1ページに表示する項目数）
-
-  // 全ページ数を計算
-  // 「チャンネルの総数/(割る)ステップ数」の余りの有無で場合分け
-  // 余りがある場合は１ページ余分に追加する
+  let page = 1; 
+  const STEP = 5; 
   const TOTAL =
     channels.length % STEP == 0
       ? channels.length / STEP
       : Math.floor(channels.length / STEP) + 1;
 
-  // ページネーションで表示される数字部分(ページ数)の要素を作成
   const paginationUl = document.querySelector(".pagination");
   let pageCount = 0;
   while (pageCount < TOTAL) {
@@ -26,7 +14,6 @@ const pagination = async () => {
     pageNumber.dataset.pageNum = pageCount + 1;
     pageNumber.innerText = pageCount + 1;
     paginationUl.appendChild(pageNumber);
-    // ページネーションの数字部分が押された時にもページが変わるように処理
     pageNumber.addEventListener("click", (e) => {
       const targetPageNum = e.target.dataset.pageNum;
       page = Number(targetPageNum);
@@ -36,16 +23,13 @@ const pagination = async () => {
     pageCount++;
   }
 
-  // 各チャンネルのタイトル(と削除ボタン)の要素を作成し、ページを表示する
   const show = (page, STEP) => {
     const ul = document.querySelector(".channel-box");
-    // 一度チャンネルリストを空にする
     ul.innerHTML = "";
 
     const firstChannelInPage = (page - 1) * STEP + 1;
     const lastChannelInPage = page * STEP;
 
-    // 各チャンネル要素の作成
     channels.forEach((channel, i) => {
       if (i < firstChannelInPage - 1 || i > lastChannelInPage - 1) return;
       const a = document.createElement("a");
@@ -55,44 +39,38 @@ const pagination = async () => {
       a.setAttribute("href", channelURL);
       li.appendChild(a);
 
-      // もしチャンネル作成者uidと自分のuidが同じだった場合は削除ボタンを追加
       if (uid === channel.user_id) {
         const deleteButton = document.createElement("button");
         deleteButton.innerHTML =
           '<i class="fa-regular fa-trash-can fa-lg"></i>';
         deleteButton.classList.add("delete-button");
         li.appendChild(deleteButton);
-        // ゴミ箱ボタンが押された時にdeleteモーダルを表示させる
+
         deleteButton.addEventListener("click", () => {
           deleteChannelModal.style.display = "flex";
           const confirmationButtonLink = document.getElementById(
             "delete-confirmation-link"
           );
-          // aタグにhrefを追加
+
           const channelURL = `/delete/${channel.id}`;
           confirmationButtonLink.setAttribute("href", channelURL);
         });
       }
-      // もしかしたら不要かもしれない要検証、本来は説明文の吹き出しがあった。
       ul.appendChild(li);
     });
   };
-  // pagination内で現在選択されているページの番号に色を付ける
+
   const colorPaginationNum = () => {
-    // ページネーションの数字部分の全要素から"colored"クラスを一旦取り除く
     const paginationArr = [...document.querySelectorAll(".pagination li")];
     paginationArr.forEach((page) => {
       page.classList.remove("colored");
     });
-    // 選択されているページにclass="colored"を追加（文字色が変わる）
     paginationArr[page - 1].classList.add("colored");
   };
 
-  // 最初に1ページ目を表示
   show(page, STEP);
   colorPaginationNum();
 
-  // 前ページ遷移
   document.getElementById("prev").addEventListener("click", () => {
     if (page <= 1) return;
     page = page - 1;
@@ -101,7 +79,6 @@ const pagination = async () => {
     loadAddChannelButton();
   });
 
-  // 次ページ遷移
   document.getElementById("next").addEventListener("click", () => {
     if (page >= channels.length / STEP) return;
     page = page + 1;
@@ -111,8 +88,6 @@ const pagination = async () => {
   });
 };
 
-// 画面がロードされる時の処理
 window.onload = () => {
-  // pagination関数（asyncが完了したらチャンネル追加ボタンを読み込む）
-  pagination().then(loadAddChannelButton);
+  pagination();
 };

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -1,136 +1,125 @@
 {% extends 'base.html' %} {% block title %}
 <title>{{ channel.name }}</title>
 {% endblock %} {% block body %}
-<div class="main-container">
-  <div class="chat-box">
-    <div id="chat-header">
-      <p id="chatroom-name">{{ channel.name }}</p>
-      {% if channel.abstract is not none %}
-      <p id="chatroom-description">{{ channel.abstract }}</p>
-      {% endif %} 
-      {% if uid == channel.user_id %}
-      <button id="channel-update-button">
-        <i class="fa-solid fa-pen-to-square fa-lg"></i>
-      </button>
-      {% include 'modal/update-channel.html' %} {% endif %}
-      <button id="to-index-button">
-        <a class="fas fa-home" href="{{ url_for('index') }}"></a>
-      </button>
-    </div>
-    <div class="pinned-message-area">
-      {% if messages.pinned is not none %}
-        {%for message in messages%}
-      <div class="pinned-message-area">
+<div class="chat-box">
+  <div id="chat-header">
+    <p id="chatroom-name">{{ channel.name }}</p>
+    {% if channel.abstract is not none %}
+    <p id="chatroom-description">{{ channel.abstract }}</p>
+    {% endif %} 
+    {% if uid == channel.user_id %}
+    <button id="channel-update-button">
+      <i class="fa-solid fa-pen-to-square fa-lg"></i>
+    </button>
+    {% include 'modal/update-channel.html' %} {% endif %}
+    <button id="to-index-button">
+      <a class="fas fa-home" href="{{ url_for('index') }}"></a>
+    </button>
+  </div>
+  {% if messages.pinned is not none %}
+    {%for message in messages%}
+      <div id="pinned-message-area">
         <p id="pinned-message">{{ messages.pinned }}</p>
       </div>
-        {% endfor %}
-      {% endif %} 
-      {%for message in messages%}
-      <div class="pinned-message-area">
-        {%for message in messages%}
-        <p id="pinned-message">{{ messages.pinned }}</p>
-        {% endfor %}
-      </div>
-      {% endfor %}
-    </div>
-    <div id="message-area">
-      {% if messages|length > 0 %} 
-        {% for message in messages %} 
-          {% if message.user_id == uid %}
-            <div class="my-messages">
-              <div class="message-options">
-                <p class="my-user-name">{{ message.user_name }}</p>
-                <div class="option-icons">
-                  {% if uid == uid %}
-                    <form action="/pin_message" method="POST">
-                      <input type="hidden" value="{{ channel.id }}" name="cid" />
-                      <button 
-                        class="pinned-message-button" 
-                        name="message_id" 
-                        value="{{ message.id }}"
-                      >
-                        <i class="fas fa-thumbtack fa-rotate-45"></i>
-                      </button>
-                    </form>
-                  {% endif %} 
-                  <form action="/delete_message" method="POST">
+    {% endfor %}
+  {% endif %} 
+  <div id="message-area">
+    {% if messages|length > 0 %} 
+      {% for message in messages %} 
+        {% if message.user_id == uid %}
+          <div class="my-messages">
+            <div class="message-options">
+              <p class="my-user-name">{{ message.user_name }}</p>
+              <div class="option-icons">
+                {% if uid == uid %}
+                  <form action="/pin_message" method="POST">
                     <input type="hidden" value="{{ channel.id }}" name="cid" />
                     <button 
-                      class="delete-message-button" 
+                      class="pinned-message-button" 
                       name="message_id" 
                       value="{{ message.id }}"
                     >
-                      <i class="far fa-trash-alt"></i>
+                      <i class="fas fa-thumbtack fa-rotate-45"></i>
                     </button>
                   </form>
-                </div>
-              </div>
-              <p class="box box-right">{{ message.message }}</p>
-              <div class="reaction-container reaction-container-right">
-                {% if message.reactioncount > 0 %}
-                  <p>
-                    <i class="fas fa-smile"></i>
-                    {{ message.reactioncount }}
-                  </p>
-                {% endif %}
-                <form action="/reaction_message" method="POST">
+                {% endif %} 
+                <form action="/delete_message" method="POST">
                   <input type="hidden" value="{{ channel.id }}" name="cid" />
                   <button 
-                    class="reaction-button" 
+                    class="delete-message-button" 
                     name="message_id" 
                     value="{{ message.id }}"
                   >
-                    <i class=" far fa-smile "></i>
+                    <i class="far fa-trash-alt"></i>
                   </button>
                 </form>
               </div>
             </div>
-          {% else %}
-            <div class="messages">
-              <p class="user-name">{{ message.user_id }}</p>
-              <p class="box box-left">{{ message.message }}</p>
-              <div class="reaction-container reaction-container-left">
-                {% if message.reactioncount > 0 %}
-                  <p>
-                    <i class="fas fa-smile"></i>
-                    {{ message.reactioncount }}
-                  </p>
-                {% endif %}
-                <form action="/reaction_message" method="POST">
-                  <input type="hidden" value="{{ channel.id }}" name="cid" />
-                  <button 
-                    class="reaction-button" 
-                    name="message_id" 
-                    value="{{ messages.id }}"
-                  >
-                    <i class=" far fa-smile "></i>
-                  </button>
-                </form>
-              </div>
+            <p class="box box-right">{{ message.message }}</p>
+            <div class="reaction-container reaction-container-right">
+              {% if message.reactioncount > 0 %}
+              <p>
+                <i class="fas fa-smile"></i>
+                {{ message.reactioncount }}
+              </p>
+              {% endif %}
+              <form action="/reaction_message" method="POST">
+                <input type="hidden" value="{{ channel.id }}" name="cid" />
+                <button 
+                  class="reaction-button" 
+                  name="message_id" 
+                  value="{{ message.id }}"
+                >
+                  <i class=" far fa-smile "></i>
+                </button>
+              </form>
             </div>
-          {% endif %} 
-        {% endfor %} 
-      {% else %}
-        <div id="no-message"><p>まだメッセージがありません</p></div>
-      {% endif %}
-    </div>
-    <div class="typing-box-wrapper">
-      <form 
-        class="typing-box" 
-        action="/message" 
-        method="POST" 
-        name="newMessageForm"
-      >
-        <textarea name="message" id="message" autofocus></textarea>
-        <input type="hidden" name="cid" value="{{ channel.id }}" />
-        <div id="message-send-tooltip">
-          <button type="submit" id="add-message-button">
-            <i class="fas fa-paper-plane"></i>
-          </button>
           </div>
+        {% else %}
+          <div class="messages">
+            <p class="user-name">{{ message.user_id }}</p>
+            <p class="box box-left">{{ message.message }}</p>
+            <div class="reaction-container reaction-container-left">
+              {% if message.reactioncount > 0 %}
+              <p>
+                <i class="fas fa-smile"></i>
+                {{ message.reactioncount }}
+              </p>
+              {% endif %}
+              <form action="/reaction_message" method="POST">
+                <input type="hidden" value="{{ channel.id }}" name="cid" />
+                <button 
+                  class="reaction-button" 
+                  name="message_id" 
+                  value="{{ messages.id }}"
+                >
+                  <i class=" far fa-smile "></i>
+                </button>
+              </form>
+            </div>
+          </div>
+        {% endif %} 
+      {% endfor %} 
+    {% else %}
+      <div id="no-message"><p>まだメッセージがありません</p></div>
+    {% endif %}
+  </div>
+  <div class="typing-box-wrapper">
+    <form 
+      class="typing-box" 
+      action="/message" 
+      method="POST" 
+      name="newMessageForm"
+    >
+      <textarea name="message" id="message" autofocus></textarea>
+      <input type="hidden" name="cid" value="{{ channel.id }}" />
+      <div id="message-send-tooltip">
+        <button type="submit" id="add-message-button">
+          <i class="fas fa-paper-plane"></i>
+        </button>
         </div>
-      </form>
-    </div>
+      </div>
+    </form>
 </div>
 {% endblock %}{% block script %}
 <script type="text/javascript">
@@ -145,5 +134,9 @@
 <script
   src="{{url_for('static',filename='js/scroll-message.js')}}"
   type="text/javascript"
+></script>
+<script
+src="{{url_for('static',filename='JS/chatbox-size.js')}}"
+type="text/javascript"
 ></script>
 {% endblock %}

--- a/ChatApp/templates/error/error.html
+++ b/ChatApp/templates/error/error.html
@@ -5,7 +5,7 @@
   <div class="error-container">
     <img class="error-logo" src="{{ url_for('static',filename='img/logo.png') }}" alt="logo">
     <div class="error-body">
-      <h1 class="error-title">エラー</h1>
+      <h2 class="error-title">Error</h2>
         <p>管理者にお問い合わせください。</p>
         <a class="switch-register-mode" href="{{ url_for('login') }}">ログイン画面へもどる
         </a>

--- a/ChatApp/templates/registration/login.html
+++ b/ChatApp/templates/registration/login.html
@@ -32,7 +32,7 @@
           <button class="registration-button">ログイン</button>         
         </div>
         {% with messages = get_flashed_messages() %} {% if messages %}
-        <div id="error-message">
+        <div class="flashes">
           {% for message in messages %}
           <p>{{ message }}</p>
           {% endfor %}

--- a/ChatApp/templates/registration/signup.html
+++ b/ChatApp/templates/registration/signup.html
@@ -109,8 +109,7 @@
               />私は教員です
             </label>
           </div>
-
-          <div class="test">
+          <div>
             <span id="visibility">
               <div class="teachers-passform">
                 <label for="teachers-password-input">
@@ -133,7 +132,6 @@
             </ul>
             {% endif %}
           </div>
-
         </div>
         <div class="registration-button-container">
           <button class="registration-button">アカウントを登録する</button>         


### PR DESCRIPTION
## 実装概要
・404，500でもないエラー画面のレスポンシブの際に改行されて表示されてしまったため、修正。
・トーク一覧にてトーク表示の高さを修正
　⇨ピン留めメッセージが表示されているorされていないで表示位置を可変するJSを作成
・paginationが複数表示される場合の表記を修正。
・トーク一覧にて１ページに用事されるチャンネル数を５つに変更
・ログイン画面のエラー文言のカラーを指定
・signup.htmlにて不要なクラスの削除

## 検証の際は・・・
detail.htmlに以下コードが２箇所ありますので、こちらを削除いただくとエラーが出ないようになります。
`              
{% if message.reactioncount > 0 %}
              <p>
                <i class="fas fa-smile"></i>
                {{ message.reactioncount }}
              </p>
{% endif %}
`
※リアクションの受け渡しで今後使う予定です。

## 保留/やらないこと (なければ書かなくて良い)
ピン留め・リアクションについては後日また修正予定