### PR TITLE
feature/Frontend-173-3

### DIFF
--- a/ChatApp/static/CSS/error.css
+++ b/ChatApp/static/CSS/error.css
@@ -28,5 +28,9 @@
 .error-body h1{
   font-size: 100px;
   letter-spacing: 0.5em;
-  margin-right: -0.5em;
+}
+
+.error-body h1:after {
+  content: " ";
+  margin-left: -.5em;
 }

--- a/ChatApp/static/CSS/modal.css
+++ b/ChatApp/static/CSS/modal.css
@@ -115,9 +115,31 @@
   background-color: var(--orange);
 }
 
+#delete-confirmation-link{
+  width:30%;
+  margin-top: 5px;
+  margin-left: auto;
+  margin-right: 14%;
+}
+#delete-channel-confirmation-button{
+  width: 100%;
+}
+
 @media screen and (max-width: 768px) {
   .modal-body button {
     margin: inherit;
     width: calc(70% + 1rem);
+  }
+}
+
+@media screen and (max-width: 431px) {
+  .modal-header h1 {
+    font-size: medium;
+  }
+}
+
+@media screen and (max-width: 705px) {
+  .modal-body p {
+    width: 100%;
   }
 }

--- a/ChatApp/templates/detail.html
+++ b/ChatApp/templates/detail.html
@@ -1,11 +1,11 @@
 {% extends 'base.html' %} {% block title %}
-<title>{{ channel.name }}</title>
+<title>{{ channel.channel_name }}</title>
 {% endblock %} {% block body %}
 <div class="chat-box">
   <div id="chat-header">
-    <p id="chatroom-name">{{ channel.name }}</p>
+    <p id="chatroom-name">{{ channel.channel_name }}</p>
     {% if channel.abstract is not none %}
-    <p id="chatroom-description">{{ channel.abstract }}</p>
+    <p id="chatroom-description">{{ channel.description }}</p>
     {% endif %} 
     {% if uid == channel.user_id %}
     <button id="channel-update-button">
@@ -16,13 +16,13 @@
       <a class="fas fa-home" href="{{ url_for('index') }}"></a>
     </button>
   </div>
-  {% if messages.pinned is not none %}
-    {%for message in messages%}
-      <div id="pinned-message-area">
-        <p id="pinned-message">{{ messages.pinned }}</p>
-      </div>
-    {% endfor %}
-  {% endif %} 
+  {% for message in messages %}
+    {% if message.pin_message == 1 %}
+    <div id="pinned-message-area">
+      <p id="pinned-message">{{ message.message }}</p>
+    </div>
+    {% endif %}
+  {% endfor %}
   <div id="message-area">
     {% if messages|length > 0 %} 
       {% for message in messages %} 
@@ -91,7 +91,7 @@
                 <button 
                   class="reaction-button" 
                   name="message_id" 
-                  value="{{ messages.id }}"
+                  value="{{ message.id }}"
                 >
                   <i class=" far fa-smile "></i>
                 </button>

--- a/ChatApp/templates/error/error.html
+++ b/ChatApp/templates/error/error.html
@@ -6,6 +6,7 @@
     <img class="error-logo" src="{{ url_for('static',filename='img/logo.png') }}" alt="logo">
     <div class="error-body">
       <h2 class="error-title">Error</h2>
+        <p>{{ error_message }}</p>
         <p>管理者にお問い合わせください。</p>
         <a class="switch-register-mode" href="{{ url_for('login') }}">ログイン画面へもどる
         </a>

--- a/ChatApp/templates/modal/delete-channel.html
+++ b/ChatApp/templates/modal/delete-channel.html
@@ -5,7 +5,7 @@
       <span class="modalClose" id="delete-page-close-button">×</span>
     </div>
     <div class="modal-body">
-      <p>削除ボタンを押すとチャンネルが消えます<br>本当によろしいですか？</p>
+      <p>削除ボタンを押すとチャンネルが消えます。<br>本当によろしいですか？</p>
       <a id="delete-confirmation-link">
         <button id="delete-channel-confirmation-button">削除</button>
       </a>

--- a/ChatApp/templates/modal/update-channel.html
+++ b/ChatApp/templates/modal/update-channel.html
@@ -4,14 +4,38 @@
       <h1>チャンネル編集</h1>
       <span class="modalClose" id="update-page-close-button">×</span>
     </div>
-    <form name="updateChannelForm" class="modal-body" action="/update_channel" method="POST">
-      <label for="channelTitle" class="channel-name">チャンネル名</label>
-      <input type="text" class="channel-form-input" name="channelTitle" />
-      <label for="channelDescription" class="channel-details">チャンネル詳細</label>
-      <input type="text" class="channel-form-input" name="channelDescription" />
-      <!-- ここのchannel.idのところ後で変更 -->
-      <input type="hidden" name="cid" value="#" />
-      <button id="add-channel-update-button">編集</button>
+    <form name="updateChannelForm" 
+      class="modal-body" 
+      action="/update_channel" 
+      method="POST"
+      >
+      <label 
+        for="channelTitle" 
+        class="channel-name">チャンネル名
+      </label>
+      <input 
+      type="text" 
+      class="channel-form-input" 
+      name="channelTitle" 
+      value="{{ channel.channel_name }}"
+      />
+      <label 
+      for="channelDescription" 
+      class="channel-details">チャンネル詳細
+      </label>
+      <input 
+      type="text" 
+      class="channel-form-input" 
+      name="channelDescription" 
+      value="{{ channel.description }}"
+      />
+      <input 
+      type="hidden" 
+      name="cid" 
+      value="{{ channel.id }}" />
+      <button 
+      id="add-channel-update-button">編集
+      </button>
     </form>
   </div>
 </div>


### PR DESCRIPTION
## 実装概要
・トーク画面にて変数の設定
　⇨ピン留めメッセージ、チャンネル名や詳細が正しく表示されるようになりました。
・チャンネル編集の変数を設定
　⇨正しくチャンネル編集できるようになりました。
・モーダルのレスポンシブ修正
・チャンネル削除モーダルの修正
　⇨ボタンより大きくリンクが設定されていたため修正。

## 保留/やらないこと (なければ書かなくて良い)
・リアクションボタン押下後、redirectされる際にスクロール位置の情報を保持するJSが作れたら作ります。
・チャンネル編集時にチャンネル名が重複した際に505エラーになってしまうため要検討。